### PR TITLE
SCRUM-102  feat(LifetimeCardTable): add quantidadeRetrabalhos column …

### DIFF
--- a/Stratify/src/components/LifetimeCardTable.vue
+++ b/Stratify/src/components/LifetimeCardTable.vue
@@ -15,6 +15,7 @@
           <b>{{ data.tempoMedio }}</b> horas
         </template>
       </Column>
+      <Column field="quantidadeRetrabalhos" header="Contagem de Retrabalho" sortable></Column>
     </DataTable>
   </div>
 </template>

--- a/Stratify/src/stores/ChartStorage.ts
+++ b/Stratify/src/stores/ChartStorage.ts
@@ -79,7 +79,8 @@ export const useChartStore = defineStore<'chart', ChartState>('chart', {
         this.lifetimeData = Array.isArray(resp)
           ? resp.map(item => ({
               descricao: item.descricao,
-              tempoMedio: item.tempoMedio
+              tempoMedio: item.tempoMedio,
+              quantidadeRetrabalhos: item.quantidadeRetrabalhos
             }))
           : [];
       } catch {


### PR DESCRIPTION
This pull request introduces a new feature to track and display the "Retrabalho" (rework) count in the `LifetimeCardTable` component. The most important changes include adding a new column to the table and updating the store to handle the additional data.

### Frontend changes:

* [`Stratify/src/components/LifetimeCardTable.vue`](diffhunk://#diff-9d4a9f5e75fb55b6b503f202365cfecf49711c8204618e39db133aaf28ff648dR18): Added a new column to the table to display the "Contagem de Retrabalho" (rework count), making it sortable.

### State management changes:

* [`Stratify/src/stores/ChartStorage.ts`](diffhunk://#diff-658cc70103764fc1e0dbfceb8ed72ff776519f55bf151625e0e5c251cde9c41cL82-R83): Updated the `useChartStore` store to include `quantidadeRetrabalhos` in the mapped data for `lifetimeData`, ensuring the new column is populated with the correct data.…to display rework count